### PR TITLE
Fixed Releases and Decomp links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Quest64: Recompiled
 Quest64: Recompiled is a project that uses [N64: Recompiled](https://github.com/Mr-Wiseguy/N64Recomp) to **statically recompile** Quest64 into a native port with many new features and enhancements. This project uses [RT64](https://github.com/rt64/rt64) as the rendering engine to provide some of these enhancements.
 
-### [Check out the latest release here](https://github.com/Rainchus/Quest64-Recomp/).
+### [Check out the latest release here](https://github.com/Rainchus/Quest64-Recomp/releases).
 
 ### **This repository and its releases do not contain game assets. The original game is required to build or run this project.**
 


### PR DESCRIPTION
The README.md file links to the Chameleon Twist Releases page and Decomp repo, despite the display text change. I've updated both links to what I believe to be correct.